### PR TITLE
Double list

### DIFF
--- a/include/list/double_list.h
+++ b/include/list/double_list.h
@@ -85,38 +85,38 @@ struct linked_list {
 #define otherwise(current) if(!current)
 
 /* Creation & Destruction */
-int linklist_alloc(struct linked_list ** list, size_t data_size);
-void linklist_free(struct linked_list ** list);
+int dl_alloc(struct linked_list ** list, size_t data_size);
+void dl_free(struct linked_list ** list);
 
 /* Data Management */
-void linklist_push_head(struct linked_list * list, void * data);
-void linklist_push_tail(struct linked_list * list, void * data);
-void * linklist_pop_head(struct linked_list * list);
-void * linklist_pop_tail(struct linked_list * list);
-bool linklist_insert(struct linked_list * list, void * data, size_t pos);
-bool linklist_delete(struct linked_list * list, size_t pos);
-void * linklist_remove(struct linked_list * list, size_t pos);
-void * linklist_fetch(struct linked_list * list, size_t pos);
+void dl_push_head(struct linked_list * list, void * data);
+void dl_push_tail(struct linked_list * list, void * data);
+void * dl_pop_head(struct linked_list * list);
+void * dl_pop_tail(struct linked_list * list);
+bool dl_insert(struct linked_list * list, void * data, size_t pos);
+bool dl_delete(struct linked_list * list, size_t pos);
+void * dl_remove(struct linked_list * list, size_t pos);
+void * dl_fetch(struct linked_list * list, size_t pos);
 
 /* Transformations */
-void linklist_map(struct linked_list * list, map_fn_t fn);
-void linklist_reverse(struct linked_list * list);
-void * linklist_foldr(const struct linked_list * list,
+void dl_map(struct linked_list * list, map_fn_t fn);
+void dl_reverse(struct linked_list * list);
+void * dl_foldr(const struct linked_list * list,
 		      foldr_fn_t fn,
 		      const void * init);
-void * linklist_foldl(const struct linked_list * list,
+void * dl_foldl(const struct linked_list * list,
 		      foldl_fn_t fn,
 		      const void * init);
 
 /* Data Properties */
-bool linklist_null(struct linked_list * list);
-bool linklist_contains(struct linked_list * list, void * data);
-bool linklist_any(struct linked_list * list, pred_fn_t p);
-bool linklist_all(struct linked_list * list, pred_fn_t p);
+bool dl_null(struct linked_list * list);
+bool dl_contains(struct linked_list * list, void * data);
+bool dl_any(struct linked_list * list, pred_fn_t p);
+bool dl_all(struct linked_list * list, pred_fn_t p);
 
 /* Filtering */
-bool linklist_filter(struct linked_list * list, pred_fn_t p);
-bool linklist_drop_while(struct linked_list * list, pred_fn_t p);
-bool linklist_take_while(struct linked_list * list, pred_fn_t p);
+bool dl_filter(struct linked_list * list, pred_fn_t p);
+bool dl_drop_while(struct linked_list * list, pred_fn_t p);
+bool dl_take_while(struct linked_list * list, pred_fn_t p);
 
 #endif /* __LINKED_LIST_H */

--- a/src/list/double_list.c
+++ b/src/list/double_list.c
@@ -229,7 +229,7 @@ static void __delete_after(struct linked_list * list, struct ll_element * mark)
 		list->head = NULL;
 }
 
-int linklist_alloc(struct linked_list ** list, size_t data_size)
+int dl_alloc(struct linked_list ** list, size_t data_size)
 {
 	int err;
 
@@ -251,7 +251,7 @@ exit:
 	return err;
 }
 
-void linklist_free(struct linked_list ** list)
+void dl_free(struct linked_list ** list)
 {
 	struct ll_element * current;
 
@@ -270,7 +270,7 @@ void linklist_free(struct linked_list ** list)
 	free(*list);
 }
 
-bool linklist_null(struct linked_list * list)
+bool dl_null(struct linked_list * list)
 {
 	bool null;
 
@@ -281,7 +281,7 @@ bool linklist_null(struct linked_list * list)
 	return null;
 }
 
-void linklist_push_head(struct linked_list * list, void * data)
+void dl_push_head(struct linked_list * list, void * data)
 {
 	struct ll_element * current;
 
@@ -292,7 +292,7 @@ void linklist_push_head(struct linked_list * list, void * data)
 	rwlock_writer_exit(list->rwlock);
 }
 
-void linklist_push_tail(struct linked_list * list, void * data)
+void dl_push_tail(struct linked_list * list, void * data)
 {
 	struct ll_element * current;
 
@@ -303,7 +303,7 @@ void linklist_push_tail(struct linked_list * list, void * data)
 	rwlock_writer_exit(list->rwlock);
 }
 
-void * linklist_pop_head(struct linked_list * list)
+void * dl_pop_head(struct linked_list * list)
 {
 	void * data = NULL;
 	struct ll_element * current;
@@ -320,7 +320,7 @@ void * linklist_pop_head(struct linked_list * list)
 	return data;
 }
 
-void * linklist_pop_tail(struct linked_list * list)
+void * dl_pop_tail(struct linked_list * list)
 {
 	void * data = NULL;
 	struct ll_element * current;
@@ -337,7 +337,7 @@ void * linklist_pop_tail(struct linked_list * list)
 	return data;
 }
 
-bool linklist_insert(struct linked_list * list, void * data, size_t pos)
+bool dl_insert(struct linked_list * list, void * data, size_t pos)
 {
 	bool success;
 	struct ll_element * current;
@@ -351,7 +351,7 @@ bool linklist_insert(struct linked_list * list, void * data, size_t pos)
 	return success;
 }
 
-bool linklist_delete(struct linked_list * list, size_t pos)
+bool dl_delete(struct linked_list * list, size_t pos)
 {
 	struct ll_element * current;
 
@@ -369,7 +369,7 @@ bool linklist_delete(struct linked_list * list, size_t pos)
 	return false;
 }
 
-void * linklist_remove(struct linked_list * list, size_t pos)
+void * dl_remove(struct linked_list * list, size_t pos)
 {
 	void * data = NULL;
 	struct ll_element * current;
@@ -386,7 +386,7 @@ void * linklist_remove(struct linked_list * list, size_t pos)
 	return data;
 }
 
-void * linklist_fetch(struct linked_list * list, size_t pos)
+void * dl_fetch(struct linked_list * list, size_t pos)
 {
 	struct ll_element * current;
 
@@ -401,7 +401,7 @@ void * linklist_fetch(struct linked_list * list, size_t pos)
 }
 
 /**
- * linklist_contains() - Determines if a list contains a value
+ * dl_contains() - Determines if a list contains a value
  * @list: The list to search
  * @data: The data to search for in the list
  *
@@ -411,7 +411,7 @@ void * linklist_fetch(struct linked_list * list, size_t pos)
  *
  * Return: ``true`` if a matching entry is found, otherwise ``false``
  */
-bool linklist_contains(struct linked_list * list, void * data)
+bool dl_contains(struct linked_list * list, void * data)
 {
 	bool success = false;
 	struct ll_element * current;
@@ -431,7 +431,7 @@ bool linklist_contains(struct linked_list * list, void * data)
 }
 
 /**
- * linklist_any() - Determines if any value in a list satisifies some condition
+ * dl_any() - Determines if any value in a list satisifies some condition
  * @list: A list of values
  * @p: The predicate function (representing a condition to be satisfied).
  *
@@ -446,12 +446,12 @@ bool linklist_contains(struct linked_list * list, void * data)
  * Return: ``true`` if there is at least one value that satisfies the predicate.
  * Otherwise, it returns ``false``.
  */
-bool linklist_any(struct linked_list * list, pred_fn_t p)
+bool dl_any(struct linked_list * list, pred_fn_t p)
 {
 	bool success = false;
 	struct ll_element * current;
 
-	if(linklist_null(list))
+	if(dl_null(list))
 		return false;
 
 	rwlock_reader_entry(list->rwlock);
@@ -469,7 +469,7 @@ bool linklist_any(struct linked_list * list, pred_fn_t p)
 }
 
 /**
- * linklist_all() - Determines if all values in a list satisify some condition
+ * dl_all() - Determines if all values in a list satisify some condition
  * @list: A list of values
  * @p: The predicate function (representing a condition to be satisfied).
  *
@@ -484,12 +484,12 @@ bool linklist_any(struct linked_list * list, pred_fn_t p)
  * Return: ``false`` if there is at least one value that does not satisfy the
  * predicate.  Otherwise, it returns ``true``.
  */
-bool linklist_all(struct linked_list * list, pred_fn_t p)
+bool dl_all(struct linked_list * list, pred_fn_t p)
 {
 	bool success = true;
 	struct ll_element * current;
 
-	if(linklist_null(list))
+	if(dl_null(list))
 		return false;
 
 	rwlock_reader_entry(list->rwlock);
@@ -506,12 +506,12 @@ bool linklist_all(struct linked_list * list, pred_fn_t p)
 	return success;
 }
 
-bool linklist_filter(struct linked_list * list, pred_fn_t p)
+bool dl_filter(struct linked_list * list, pred_fn_t p)
 {
 	bool changed = false;
 	struct ll_element * current;
 
-	if(linklist_null(list))
+	if(dl_null(list))
 		return false;
 
 	rwlock_writer_entry(list->rwlock);
@@ -531,7 +531,7 @@ bool linklist_filter(struct linked_list * list, pred_fn_t p)
 	return changed;
 }
 
-bool linklist_drop_while(struct linked_list * list, pred_fn_t p)
+bool dl_drop_while(struct linked_list * list, pred_fn_t p)
 {
 	size_t orig_length;
 	struct ll_element * current;
@@ -558,7 +558,7 @@ bool linklist_drop_while(struct linked_list * list, pred_fn_t p)
 	return (orig_length != list->length);
 }
 
-bool linklist_take_while(struct linked_list * list, pred_fn_t p)
+bool dl_take_while(struct linked_list * list, pred_fn_t p)
 {
 	size_t orig_length;
 	struct ll_element * current;
@@ -582,7 +582,7 @@ bool linklist_take_while(struct linked_list * list, pred_fn_t p)
 }
 
 /**
- * linklist_map() - Map a function over a linked list in-place.
+ * dl_map() - Map a function over a linked list in-place.
  * @list: A list of values
  * @fn: A function that will transform each value in the list
  *
@@ -594,7 +594,7 @@ bool linklist_take_while(struct linked_list * list, pred_fn_t p)
  * for i from 0 to &list->length:
  * 	@list[i] = @fn(@list[i])
  */
-void linklist_map(struct linked_list * list, map_fn_t fn)
+void dl_map(struct linked_list * list, map_fn_t fn)
 {
 	void * result;
 	struct ll_element * current;
@@ -617,13 +617,13 @@ void linklist_map(struct linked_list * list, map_fn_t fn)
 }
 
 /**
- * linklist_reverse() - Reverse a list in place.
+ * dl_reverse() - Reverse a list in place.
  * @list: The list to reverse
  *
  * Reverses a list in place so that the elements are in reverse order and the
  * head and tail are switched.
  */
-void linklist_reverse(struct linked_list * list)
+void dl_reverse(struct linked_list * list)
 {
 	struct ll_element * current;
 	struct ll_element * tmp;
@@ -641,7 +641,7 @@ void linklist_reverse(struct linked_list * list)
 }
 
 /**
- * linklist_foldr() - Right associative fold for linked lists.
+ * dl_foldr() - Right associative fold for linked lists.
  * @list: A list of values to reduce
  * @fn: A binary function that will sequentially reduce values
  * @init: An initial value for the fold
@@ -654,7 +654,7 @@ void linklist_reverse(struct linked_list * list)
  *
  * If @list is empty, the fold will be equal to the value of @init.
  */
-void * linklist_foldr(const struct linked_list * list,
+void * dl_foldr(const struct linked_list * list,
 		      foldr_fn_t fn,
 		      const void * init)
 {
@@ -685,7 +685,7 @@ void * linklist_foldr(const struct linked_list * list,
 }
 
 /**
- * linklist_foldl() - Left associative fold for linked lists.
+ * dl_foldl() - Left associative fold for linked lists.
  * @list: A list of values to reduce
  * @fn: A binary function that will sequentially reduce values
  * @init: An initial value for the fold
@@ -698,7 +698,7 @@ void * linklist_foldr(const struct linked_list * list,
  *
  * If @list is empty, the fold will be equal to the value of @init.
  */
-void * linklist_foldl(const struct linked_list * list,
+void * dl_foldl(const struct linked_list * list,
 		      foldl_fn_t fn,
 		      const void * init)
 {

--- a/test/list/double_list.c
+++ b/test/list/double_list.c
@@ -21,72 +21,72 @@
 
 #include "list/double_list.h"
 
-START_TEST(test_linklist_alloc)
+START_TEST(test_dl_alloc)
 {
 	int err;
 	struct linked_list * list = NULL;
 
-	err = linklist_alloc(&list, 0);
+	err = dl_alloc(&list, 0);
 
 	ck_assert(!err);
 	ck_assert(list);
 	ck_assert_int_eq(list->length, 0);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_null_true)
+START_TEST(test_dl_null_true)
 {
 	struct linked_list * list;
 
-	linklist_alloc(&list, 0);
-	ck_assert(linklist_null(list));
-	linklist_free(&list);
+	dl_alloc(&list, 0);
+	ck_assert(dl_null(list));
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_null_false)
-{
-	uint8_t val = 1;
-	struct linked_list * list;
-
-	linklist_alloc(&list, sizeof(val));
-	linklist_push_head(list, &val);
-	ck_assert(!linklist_null(list));
-	linklist_free(&list);
-}
-END_TEST
-
-START_TEST(test_linklist_push_head_single)
+START_TEST(test_dl_null_false)
 {
 	uint8_t val = 1;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(val));
-	linklist_push_head(list, &val);
+	dl_alloc(&list, sizeof(val));
+	dl_push_head(list, &val);
+	ck_assert(!dl_null(list));
+	dl_free(&list);
+}
+END_TEST
+
+START_TEST(test_dl_push_head_single)
+{
+	uint8_t val = 1;
+	struct linked_list * list;
+
+	dl_alloc(&list, sizeof(val));
+	dl_push_head(list, &val);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 	ck_assert_int_eq(*(uint8_t *) list->head->data, val);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_push_head_multiple)
+START_TEST(test_dl_push_head_multiple)
 {
 	uint8_t val1 = 1;
 	uint8_t val2 = 2;
 	uint8_t val3 = 3;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(val1));
+	dl_alloc(&list, sizeof(val1));
 
-	linklist_push_head(list, &val1);
-	linklist_push_head(list, &val2);
-	linklist_push_head(list, &val3);
+	dl_push_head(list, &val1);
+	dl_push_head(list, &val2);
+	dl_push_head(list, &val3);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -100,39 +100,39 @@ START_TEST(test_linklist_push_head_multiple)
 	ck_assert_int_eq(*(uint8_t *) current->data, val1);
 	ck_assert(!current->next);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_push_tail_single)
+START_TEST(test_dl_push_tail_single)
 {
 	uint8_t val = 1;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &val);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &val);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 	ck_assert_int_eq(*(uint8_t *) list->head->data, val);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_push_tail_multiple)
+START_TEST(test_dl_push_tail_multiple)
 {
 	uint8_t val1 = 1;
 	uint8_t val2 = 2;
 	uint8_t val3 = 3;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	linklist_push_tail(list, &val1);
-	linklist_push_tail(list, &val2);
-	linklist_push_tail(list, &val3);
+	dl_push_tail(list, &val1);
+	dl_push_tail(list, &val2);
+	dl_push_tail(list, &val3);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -146,50 +146,50 @@ START_TEST(test_linklist_push_tail_multiple)
 	ck_assert_int_eq(*(uint8_t *) current->data, val3);
 	ck_assert(!current->next);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_pop_head_empty)
+START_TEST(test_dl_pop_head_empty)
 {
 	void * val;
 	struct linked_list * list;
 
-	linklist_alloc(&list, 0);
+	dl_alloc(&list, 0);
 
-	val = linklist_pop_head(list);
+	val = dl_pop_head(list);
 
 	ck_assert(!val);
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_pop_head_single)
+START_TEST(test_dl_pop_head_single)
 {
 	uint8_t val = 1;
 	uint8_t * out;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(val));
-	linklist_push_head(list, &val);
+	dl_alloc(&list, sizeof(val));
+	dl_push_head(list, &val);
 
-	out = linklist_pop_head(list);
+	out = dl_pop_head(list);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out);
-	linklist_free(&list);
+	dl_free(&list);
 
 }
 END_TEST
 
-START_TEST(test_linklist_pop_head_multiple)
+START_TEST(test_dl_pop_head_multiple)
 {
 	uint8_t in1 = 1;
 	uint8_t in2 = 2;
@@ -199,15 +199,15 @@ START_TEST(test_linklist_pop_head_multiple)
 	uint8_t * out3;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	linklist_push_head(list, &in1);
-	linklist_push_head(list, &in2);
-	linklist_push_head(list, &in3);
+	dl_push_head(list, &in1);
+	dl_push_head(list, &in2);
+	dl_push_head(list, &in3);
 
-	out1 = (uint8_t *) linklist_pop_head(list);
-	out2 = (uint8_t *) linklist_pop_head(list);
-	out3 = (uint8_t *) linklist_pop_head(list);
+	out1 = (uint8_t *) dl_pop_head(list);
+	out2 = (uint8_t *) dl_pop_head(list);
+	out3 = (uint8_t *) dl_pop_head(list);
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -219,54 +219,54 @@ START_TEST(test_linklist_pop_head_multiple)
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out1);
 	free(out2);
 	free(out3);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_pop_tail_empty)
+START_TEST(test_dl_pop_tail_empty)
 {
 	void * val;
 	struct linked_list * list;
 
-	linklist_alloc(&list, 0);
+	dl_alloc(&list, 0);
 
-	val = linklist_pop_tail(list);
+	val = dl_pop_tail(list);
 
 	ck_assert(!val);
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_pop_tail_single)
+START_TEST(test_dl_pop_tail_single)
 {
 	uint8_t in = 1;
 	uint8_t * out;
 	struct linked_list * list;
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_tail(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_tail(list, &in);
 
-	out = linklist_pop_tail(list);
+	out = dl_pop_tail(list);
 
 	ck_assert_int_eq(*out, in);
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_pop_tail_multiple)
+START_TEST(test_dl_pop_tail_multiple)
 {
 	uint8_t in1 = 1;
 	uint8_t in2 = 2;
@@ -276,15 +276,15 @@ START_TEST(test_linklist_pop_tail_multiple)
 	uint8_t * out3;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
 
-	out1 = linklist_pop_tail(list);
-	out2 = linklist_pop_tail(list);
-	out3 = linklist_pop_tail(list);
+	out1 = dl_pop_tail(list);
+	out2 = dl_pop_tail(list);
+	out3 = dl_pop_tail(list);
 
 	ck_assert_int_eq(*out1, in3);
 	ck_assert_int_eq(*out2, in2);
@@ -292,35 +292,35 @@ START_TEST(test_linklist_pop_tail_multiple)
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out1);
 	free(out2);
 	free(out3);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_insert_single)
+START_TEST(test_dl_insert_single)
 {
 	uint8_t in = 1;
 	bool success;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	success = linklist_insert(list, &in, 0);
+	success = dl_insert(list, &in, 0);
 
 	ck_assert(success);
 	ck_assert(list->head);
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_insert_multiple)
+START_TEST(test_dl_insert_multiple)
 {
 	bool r1;
 	bool r2;
@@ -337,14 +337,14 @@ START_TEST(test_linklist_insert_multiple)
 
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
 	/* Insert the elements out of order. */
 	/* [4 1 2 3] */
-	r1 = linklist_insert(list, &in1, 0);
-	r2 = linklist_insert(list, &in3, 1);
-	r3 = linklist_insert(list, &in2, 1);
-	r4 = linklist_insert(list, &in4, 0);
+	r1 = dl_insert(list, &in1, 0);
+	r2 = dl_insert(list, &in3, 1);
+	r3 = dl_insert(list, &in2, 1);
+	r4 = dl_insert(list, &in4, 0);
 
 	ck_assert(r1);
 	ck_assert(r2);
@@ -355,10 +355,10 @@ START_TEST(test_linklist_insert_multiple)
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 4);
 
-	out1 = linklist_pop_head(list); /* 4 */
-	out2 = linklist_pop_head(list); /* 1 */
-	out3 = linklist_pop_head(list); /* 2 */
-	out4 = linklist_pop_head(list); /* 3 */
+	out1 = dl_pop_head(list); /* 4 */
+	out2 = dl_pop_head(list); /* 1 */
+	out3 = dl_pop_head(list); /* 2 */
+	out4 = dl_pop_head(list); /* 3 */
 
 	ck_assert_int_eq(*out1, in4);
 	ck_assert_int_eq(*out2, in1);
@@ -369,33 +369,33 @@ START_TEST(test_linklist_insert_multiple)
 	free(out2);
 	free(out3);
 	free(out4);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_delete_empty)
+START_TEST(test_dl_delete_empty)
 {
 	bool r1;
 	bool r2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	r1 = linklist_delete(list, 0);
-	r2 = linklist_delete(list, 1);
+	r1 = dl_delete(list, 0);
+	r2 = dl_delete(list, 1);
 
 	ck_assert(!r1);
 	ck_assert(!r2);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_delete_single)
+START_TEST(test_dl_delete_single)
 {
 	uint8_t in = 1;
 	bool r1;
@@ -403,12 +403,12 @@ START_TEST(test_linklist_delete_single)
 	bool r3;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	r1 = linklist_delete(list, 1); /* [1] -> [1] (false) */
-	r2 = linklist_delete(list, 0); /* [1] -> [] (true) */
-	r3 = linklist_delete(list, 0); /* [] -> [] (false) */
+	r1 = dl_delete(list, 1); /* [1] -> [1] (false) */
+	r2 = dl_delete(list, 0); /* [1] -> [] (true) */
+	r3 = dl_delete(list, 0); /* [] -> [] (false) */
 
 	ck_assert(!r1);
 	ck_assert(r2);
@@ -416,13 +416,13 @@ START_TEST(test_linklist_delete_single)
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_delete_multiple)
+START_TEST(test_dl_delete_multiple)
 {
 	uint8_t in1 = 1;
 	uint8_t in2 = 2;
@@ -436,27 +436,27 @@ START_TEST(test_linklist_delete_multiple)
 	struct linked_list * list;
 
 	/* Create linked list: [1, 2, 3, 4] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
-	linklist_push_tail(list, &in4);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
+	dl_push_tail(list, &in4);
 
 	/* Drop the elements out of order. */
 	/* [1, 2, 3, 4] -> [1, 2, 4] (true) */
-	r1 = linklist_delete(list, 2);
+	r1 = dl_delete(list, 2);
 	/* [1, 2, 4] -> [2, 4] (true) */
-	r2 = linklist_delete(list, 0);
+	r2 = dl_delete(list, 0);
 	/* [2, 4] -> [2] (true) */
-	r3 = linklist_delete(list, 1);
+	r3 = dl_delete(list, 1);
 	/* [2] -> [] (true) */
-	r4 = linklist_delete(list, 0);
+	r4 = dl_delete(list, 0);
 	/* [] -> [] (false) */
-	r5 = linklist_delete(list, 0);
+	r5 = dl_delete(list, 0);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	ck_assert(r1);
 	ck_assert(r2);
@@ -464,56 +464,56 @@ START_TEST(test_linklist_delete_multiple)
 	ck_assert(r4);
 	ck_assert(!r5);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_remove_empty)
+START_TEST(test_dl_remove_empty)
 {
 	void * val1;
 	void * val2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	val1 = linklist_remove(list, 0);
-	val2 = linklist_remove(list, 1);
+	val1 = dl_remove(list, 0);
+	val2 = dl_remove(list, 1);
 
 	ck_assert(!val1);
 	ck_assert(!val2);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_remove_single)
+START_TEST(test_dl_remove_single)
 {
 	uint8_t in = 1;
 	uint8_t * out;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	linklist_push_head(list, &in);
-	out = linklist_remove(list, 0);
+	dl_push_head(list, &in);
+	out = dl_remove(list, 0);
 
 	ck_assert(out);
 	ck_assert_int_eq(*out, in);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_remove_multiple)
+START_TEST(test_dl_remove_multiple)
 {
 	uint8_t in1 = 1;
 	uint8_t in2 = 2;
@@ -527,27 +527,27 @@ START_TEST(test_linklist_remove_multiple)
 	struct linked_list * list;
 
 	/* Create linked list: [1, 2, 3, 4] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
-	linklist_push_tail(list, &in4);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
+	dl_push_tail(list, &in4);
 
 	/* Remove the elements out of order. */
 	/* [1, 2, 3, 4] -> [1, 2, 4] (3) */
-	out1 = linklist_remove(list, 2);
+	out1 = dl_remove(list, 2);
 	/* [1, 2, 4] -> [2, 4] (1) */
-	out2 = linklist_remove(list, 0);
+	out2 = dl_remove(list, 0);
 	/* [2, 4] -> [2] (4) */
-	out3 = linklist_remove(list, 1);
+	out3 = dl_remove(list, 1);
 	/* [2] -> [] (2) */
-	out4 = linklist_remove(list, 0);
+	out4 = dl_remove(list, 0);
 	/* [] -> [] (NULL) */
-	out5 = linklist_remove(list, 0);
+	out5 = dl_remove(list, 0);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -564,42 +564,42 @@ START_TEST(test_linklist_remove_multiple)
 	free(out2);
 	free(out3);
 	free(out4);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_fetch_empty)
+START_TEST(test_dl_fetch_empty)
 {
 	void * val1;
 	void * val2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, 0);
+	dl_alloc(&list, 0);
 
-	val1 = linklist_fetch(list, 0);
-	val2 = linklist_fetch(list, 1);
+	val1 = dl_fetch(list, 0);
+	val2 = dl_fetch(list, 1);
 
 	ck_assert(!val1);
 	ck_assert(!val2);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_fetch_single)
+START_TEST(test_dl_fetch_single)
 {
 	uint8_t in = 1;
 	uint8_t * out;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	out = linklist_fetch(list, 0);
+	out = dl_fetch(list, 0);
 
 	ck_assert(out);
 	ck_assert_int_eq(*out, in);
@@ -608,11 +608,11 @@ START_TEST(test_linklist_fetch_single)
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_fetch_multiple)
+START_TEST(test_dl_fetch_multiple)
 {
 	uint8_t in1 = 1;
 	uint8_t in2 = 2;
@@ -625,20 +625,20 @@ START_TEST(test_linklist_fetch_multiple)
 	uint8_t * out5;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
 	/* Create linked list: [1, 2, 3, 4] */
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
-	linklist_push_tail(list, &in4);
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
+	dl_push_tail(list, &in4);
 
 	/* Fetch the elements out of order. */
-	out1 = linklist_fetch(list, 2); /* 3 */
-	out2 = linklist_fetch(list, 0); /* 1 */
-	out3 = linklist_fetch(list, 1); /* 2 */
-	out4 = linklist_fetch(list, 3); /* 4 */
-	out5 = linklist_fetch(list, 4); /* NULL */
+	out1 = dl_fetch(list, 2); /* 3 */
+	out2 = dl_fetch(list, 0); /* 1 */
+	out3 = dl_fetch(list, 1); /* 2 */
+	out4 = dl_fetch(list, 3); /* 4 */
+	out5 = dl_fetch(list, 4); /* NULL */
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -655,31 +655,31 @@ START_TEST(test_linklist_fetch_multiple)
 	ck_assert_int_eq(*out3, in2);
 	ck_assert_int_eq(*out4, in4);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_contains_empty)
+START_TEST(test_dl_contains_empty)
 {
 	bool found;
 	uint8_t val = 1;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	found = linklist_contains(list, &val);
+	found = dl_contains(list, &val);
 
 	ck_assert(!found);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_contains_single)
+START_TEST(test_dl_contains_single)
 {
 	bool found1;
 	bool found2;
@@ -688,11 +688,11 @@ START_TEST(test_linklist_contains_single)
 	uint8_t val2 = 2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	found1 = linklist_contains(list, &val1);
-	found2 = linklist_contains(list, &val2);
+	found1 = dl_contains(list, &val1);
+	found2 = dl_contains(list, &val2);
 
 	ck_assert(found1);
 	ck_assert(!found2);
@@ -701,11 +701,11 @@ START_TEST(test_linklist_contains_single)
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_contains_multiple)
+START_TEST(test_dl_contains_multiple)
 {
 	bool found[5];
 	uint8_t in[] = {1, 2, 3, 4};
@@ -713,18 +713,18 @@ START_TEST(test_linklist_contains_multiple)
 	struct linked_list * list;
 
 	/* Create linked list: [1, 2, 3, 4] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
-	linklist_push_tail(list, &in[3]);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
+	dl_push_tail(list, &in[3]);
 
 	/* Check the elements out of order. */
-	found[0] = linklist_contains(list, &val[2]);
-	found[1] = linklist_contains(list, &val[0]);
-	found[2] = linklist_contains(list, &val[1]);
-	found[3] = linklist_contains(list, &val[3]);
-	found[4] = linklist_contains(list, &val[4]);
+	found[0] = dl_contains(list, &val[2]);
+	found[1] = dl_contains(list, &val[0]);
+	found[2] = dl_contains(list, &val[1]);
+	found[3] = dl_contains(list, &val[3]);
+	found[4] = dl_contains(list, &val[4]);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -736,7 +736,7 @@ START_TEST(test_linklist_contains_multiple)
 	ck_assert(found[3]);
 	ck_assert(!found[4]);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
@@ -750,36 +750,36 @@ bool pred_lte1(uint8_t * n)
 	return (*n <= 1);
 }
 
-START_TEST(test_linklist_any_empty)
+START_TEST(test_dl_any_empty)
 {
 	bool any;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	any = linklist_any(list, (pred_fn_t) pred_gte1);
+	any = dl_any(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(!any);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_any_single)
+START_TEST(test_dl_any_single)
 {
 	bool any[2];
 	uint8_t in = 0;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	any[0] = linklist_any(list, (pred_fn_t) pred_gte1);
-	any[1] = linklist_any(list, (pred_fn_t) pred_lte1);
+	any[0] = dl_any(list, (pred_fn_t) pred_gte1);
+	any[1] = dl_any(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(!any[0]);
 	ck_assert(any[1]);
@@ -788,25 +788,25 @@ START_TEST(test_linklist_any_single)
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_any_multiple)
+START_TEST(test_dl_any_multiple)
 {
 	bool any[2];
 	uint8_t in[] = {2, 3, 4};
 	struct linked_list * list;
 
 	/* Create linked list: [1, 2, 3, 4] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
 
 	/* Check the elements out of order. */
-	any[0] = linklist_any(list, (pred_fn_t) pred_gte1);
-	any[1] = linklist_any(list, (pred_fn_t) pred_lte1);
+	any[0] = dl_any(list, (pred_fn_t) pred_gte1);
+	any[1] = dl_any(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -815,40 +815,40 @@ START_TEST(test_linklist_any_multiple)
 	ck_assert(any[0]);
 	ck_assert(!any[1]);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_all_empty)
+START_TEST(test_dl_all_empty)
 {
 	bool all;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	all = linklist_all(list, (pred_fn_t) pred_gte1);
+	all = dl_all(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(!all);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_all_single)
+START_TEST(test_dl_all_single)
 {
 	bool all[2];
 	uint8_t in = 0;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	all[0] = linklist_all(list, (pred_fn_t) pred_gte1);
-	all[1] = linklist_all(list, (pred_fn_t) pred_lte1);
+	all[0] = dl_all(list, (pred_fn_t) pred_gte1);
+	all[1] = dl_all(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(!all[0]);
 	ck_assert(all[1]);
@@ -857,25 +857,25 @@ START_TEST(test_linklist_all_single)
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_all_multiple)
+START_TEST(test_dl_all_multiple)
 {
 	bool all[2];
 	uint8_t in[] = {2, 3, 4};
 	struct linked_list * list;
 
 	/* Create linked list: [1, 2, 3, 4] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
 
 	/* Check the elements out of order. */
-	all[0] = linklist_all(list, (pred_fn_t) pred_gte1);
-	all[1] = linklist_all(list, (pred_fn_t) pred_lte1);
+	all[0] = dl_all(list, (pred_fn_t) pred_gte1);
+	all[1] = dl_all(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -884,71 +884,71 @@ START_TEST(test_linklist_all_multiple)
 	ck_assert(all[0]);
 	ck_assert(!all[1]);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_filter_empty)
+START_TEST(test_dl_filter_empty)
 {
 	bool changed;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	changed = linklist_filter(list, (pred_fn_t) pred_gte1);
+	changed = dl_filter(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(!changed);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_filter_single)
+START_TEST(test_dl_filter_single)
 {
 	bool changed;
 	uint8_t in = 0;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	changed = linklist_filter(list, (pred_fn_t) pred_lte1);
+	changed = dl_filter(list, (pred_fn_t) pred_lte1);
 	ck_assert(!changed);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	changed = linklist_filter(list, (pred_fn_t) pred_gte1);
+	changed = dl_filter(list, (pred_fn_t) pred_gte1);
 	ck_assert(changed);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_filter_multiple)
+START_TEST(test_dl_filter_multiple)
 {
 	bool changed;
 	uint8_t in[] = {0, 2, 0, 2};
 	struct linked_list * list;
 
 	/* Create linked list: [0, 2, 0, 2] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
-	linklist_push_tail(list, &in[3]);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
+	dl_push_tail(list, &in[3]);
 
 	/* filter (> 1) [0, 2, 0, 2] -> [0, 0] */
-	changed = linklist_filter(list, (pred_fn_t) pred_gte1);
+	changed = dl_filter(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(changed);
 
@@ -957,49 +957,49 @@ START_TEST(test_linklist_filter_multiple)
 	ck_assert_int_eq(list->length, 2);
 
 	/* filter (<= 1) [0, 0] -> [] */
-	changed = linklist_filter(list, (pred_fn_t) pred_lte1);
+	changed = dl_filter(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(changed);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_drop_while_empty)
+START_TEST(test_dl_drop_while_empty)
 {
 	bool changed;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	changed = linklist_drop_while(list, (pred_fn_t) pred_gte1);
+	changed = dl_drop_while(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(!changed);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_drop_while_single)
+START_TEST(test_dl_drop_while_single)
 {
 	bool changed;
 	uint8_t in = 0;
 	struct linked_list * list;
 
 	/* Singleton List: [0] */
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
 	/* dropWhile (> 1) [0] -> [0] */
-	changed = linklist_drop_while(list, (pred_fn_t) pred_gte1);
+	changed = dl_drop_while(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(!changed);
 	ck_assert(list->head);
@@ -1007,34 +1007,34 @@ START_TEST(test_linklist_drop_while_single)
 	ck_assert_int_eq(list->length, 1);
 
 	/* dropWhile (<= 1) [0] -> [] */
-	changed = linklist_drop_while(list, (pred_fn_t) pred_lte1);
+	changed = dl_drop_while(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(changed);
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_drop_while_multiple)
+START_TEST(test_dl_drop_while_multiple)
 {
 	bool changed;
 	uint8_t in[6] = {0, 0, 2, 2, 0, 0};
 	struct linked_list * list;
 
 	/* Create linked list: [0, 0, 2, 2, 0, 0] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
-	linklist_push_tail(list, &in[3]);
-	linklist_push_tail(list, &in[4]);
-	linklist_push_tail(list, &in[5]);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
+	dl_push_tail(list, &in[3]);
+	dl_push_tail(list, &in[4]);
+	dl_push_tail(list, &in[5]);
 
 	/* dropWhile (<= 1) [0, 0, 2, 2, 0, 0] -> [2, 2, 0, 0] */
-	changed = linklist_drop_while(list, (pred_fn_t) pred_lte1);
+	changed = dl_drop_while(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(changed);
 	ck_assert(list->head);
@@ -1042,48 +1042,48 @@ START_TEST(test_linklist_drop_while_multiple)
 	ck_assert_int_eq(list->length, 4);
 
 	/* dropWhile (> 1) [2, 2, 0, 0] -> [0, 0]*/
-	changed = linklist_drop_while(list, (pred_fn_t) pred_gte1);
+	changed = dl_drop_while(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(changed);
 	ck_assert(list->head);
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 2);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_take_while_empty)
+START_TEST(test_dl_take_while_empty)
 {
 	bool changed;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	changed = linklist_take_while(list, (pred_fn_t) pred_gte1);
+	changed = dl_take_while(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(!changed);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_take_while_single)
+START_TEST(test_dl_take_while_single)
 {
 	bool changed;
 	uint8_t in = 0;
 	struct linked_list * list;
 
 	/* Singleton List: [0] */
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
 	/* takeWhile (<= 1) [0] -> [0] */
-	changed = linklist_take_while(list, (pred_fn_t) pred_lte1);
+	changed = dl_take_while(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(!changed);
 	ck_assert(list->head);
@@ -1091,31 +1091,31 @@ START_TEST(test_linklist_take_while_single)
 	ck_assert_int_eq(list->length, 1);
 
 	/* takeWhile (> 1) [0] -> [] */
-	changed = linklist_take_while(list, (pred_fn_t) pred_gte1);
+	changed = dl_take_while(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(changed);
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_take_while_multiple)
+START_TEST(test_dl_take_while_multiple)
 {
 	bool changed;
 	uint8_t in[] = {1, 0, 2};
 	struct linked_list * list;
 
 	/* Create linked list: [1, 0, 2] */
-	linklist_alloc(&list, sizeof(uint8_t));
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
+	dl_alloc(&list, sizeof(uint8_t));
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
 
 	/* takeWhile (<= 1) [1, 0, 2] -> [1, 0] */
-	changed = linklist_take_while(list, (pred_fn_t) pred_lte1);
+	changed = dl_take_while(list, (pred_fn_t) pred_lte1);
 
 	ck_assert(changed);
 	ck_assert(list->head);
@@ -1123,14 +1123,14 @@ START_TEST(test_linklist_take_while_multiple)
 	ck_assert_int_eq(list->length, 2);
 
 	/* dropWhile (> 1) [1, 0] -> [1]*/
-	changed = linklist_take_while(list, (pred_fn_t) pred_gte1);
+	changed = dl_take_while(list, (pred_fn_t) pred_gte1);
 
 	ck_assert(changed);
 	ck_assert(list->head);
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
@@ -1151,37 +1151,37 @@ uint8_t * map_fn_newptr(uint8_t * data)
 	return n;
 }
 
-START_TEST(test_linklist_map_empty)
+START_TEST(test_dl_map_empty)
 {
 	struct linked_list * list;
 
-	linklist_alloc(&list, 0);
+	dl_alloc(&list, 0);
 
-	linklist_map(list, (map_fn_t) map_fn);
-	linklist_map(list, (map_fn_t) map_fn_newptr);
+	dl_map(list, (map_fn_t) map_fn);
+	dl_map(list, (map_fn_t) map_fn_newptr);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_map_single)
+START_TEST(test_dl_map_single)
 {
 	uint8_t in = 1;
 	uint8_t * out;
 	struct linked_list * list;
 
 	/* Create single element list [1] */
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
 	/* Map two increment functions over the list. */
-	linklist_map(list, (map_fn_t) map_fn); /* [1] -> [2] */
-	linklist_map(list, (map_fn_t) map_fn_newptr); /* [2] -> [3] */
-	out = linklist_fetch(list, 0);
+	dl_map(list, (map_fn_t) map_fn); /* [1] -> [2] */
+	dl_map(list, (map_fn_t) map_fn_newptr); /* [2] -> [3] */
+	out = dl_fetch(list, 0);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -1189,11 +1189,11 @@ START_TEST(test_linklist_map_single)
 
 	ck_assert_int_eq(*out, in + 2);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_map_multiple)
+START_TEST(test_dl_map_multiple)
 {
 	uint8_t in1 = 1;
 	uint8_t in2 = 2;
@@ -1203,21 +1203,21 @@ START_TEST(test_linklist_map_multiple)
 	uint8_t * out3;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in1));
+	dl_alloc(&list, sizeof(in1));
 
 	/* list: [1, 2, 3] */
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
 
 	/* [1, 2, 3] -> [2, 3, 4] */
-	linklist_map(list, (map_fn_t) map_fn);
+	dl_map(list, (map_fn_t) map_fn);
 	/* [2, 3, 4] -> [3, 4, 5] */
-	linklist_map(list, (map_fn_t) map_fn_newptr);
+	dl_map(list, (map_fn_t) map_fn_newptr);
 
-	out1 = linklist_fetch(list, 0);
-	out2 = linklist_fetch(list, 1);
-	out3 = linklist_fetch(list, 2);
+	out1 = dl_fetch(list, 0);
+	out2 = dl_fetch(list, 1);
+	out3 = dl_fetch(list, 2);
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -1227,38 +1227,38 @@ START_TEST(test_linklist_map_multiple)
 	ck_assert_int_eq(*out2, in2 + 2);
 	ck_assert_int_eq(*out3, in3 + 2);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_reverse_empty)
+START_TEST(test_dl_reverse_empty)
 {
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	linklist_reverse(list);
+	dl_reverse(list);
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_reverse_single)
+START_TEST(test_dl_reverse_single)
 {
 	uint8_t in = 1;
 	uint8_t * out;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	linklist_reverse(list);
+	dl_reverse(list);
 
-	out = linklist_fetch(list, 0);
+	out = dl_fetch(list, 0);
 	ck_assert(out);
 	ck_assert_int_eq(*out, in);
 
@@ -1266,30 +1266,30 @@ START_TEST(test_linklist_reverse_single)
 	ck_assert(list->tail);
 	ck_assert_int_eq(list->length, 1);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_reverse_multiple)
+START_TEST(test_dl_reverse_multiple)
 {
 	uint8_t in[3] = {1, 2, 3};
 	uint8_t * out[3];
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
 	/* Create linked list: [1, 2, 3] */
-	linklist_push_tail(list, &in[0]);
-	linklist_push_tail(list, &in[1]);
-	linklist_push_tail(list, &in[2]);
+	dl_push_tail(list, &in[0]);
+	dl_push_tail(list, &in[1]);
+	dl_push_tail(list, &in[2]);
 
 	/* Reverse the list: [1, 2, 3] -> [3, 2, 1] */
-	linklist_reverse(list);
+	dl_reverse(list);
 
 	/* Fetch the elements in order. */
-	out[0] = linklist_fetch(list, 0); /* 3 */
-	out[1] = linklist_fetch(list, 1); /* 2 */
-	out[2] = linklist_fetch(list, 2); /* 1 */
+	out[0] = dl_fetch(list, 0); /* 3 */
+	out[1] = dl_fetch(list, 1); /* 2 */
+	out[2] = dl_fetch(list, 2); /* 1 */
 
 	ck_assert(list->head);
 	ck_assert(list->tail);
@@ -1303,7 +1303,7 @@ START_TEST(test_linklist_reverse_multiple)
 	ck_assert_int_eq(*out[1], in[1]);
 	ck_assert_int_eq(*out[2], in[0]);
 
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
@@ -1360,17 +1360,17 @@ int8_t * generic_fold_fn(const int8_t * a, const int8_t * b)
 	return n;
 }
 
-START_TEST(test_linklist_foldr_empty)
+START_TEST(test_dl_foldr_empty)
 {
 	int8_t init = 0;
 	int8_t * out1;
 	int8_t * out2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(uint8_t));
+	dl_alloc(&list, sizeof(uint8_t));
 
-	out1 = linklist_foldr(list, (foldr_fn_t) foldr_fn, &init);
-	out2 = linklist_foldr(list, (foldr_fn_t) generic_fold_fn, &init);
+	out1 = dl_foldr(list, (foldr_fn_t) foldr_fn, &init);
+	out2 = dl_foldr(list, (foldr_fn_t) generic_fold_fn, &init);
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -1379,15 +1379,15 @@ START_TEST(test_linklist_foldr_empty)
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out1);
 	free(out2);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_foldr_single)
+START_TEST(test_dl_foldr_single)
 {
 	int8_t in = 1;
 	int8_t init = 0;
@@ -1395,11 +1395,11 @@ START_TEST(test_linklist_foldr_single)
 	int8_t * out2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
-	out1 = linklist_foldr(list, (foldr_fn_t) foldr_fn, &init);
-	out2 = linklist_foldr(list, (foldr_fn_t) generic_fold_fn, &init);
+	out1 = dl_foldr(list, (foldr_fn_t) foldr_fn, &init);
+	out2 = dl_foldr(list, (foldr_fn_t) generic_fold_fn, &init);
 
 	ck_assert(out1);
 	ck_assert_int_eq(*out1, 1);
@@ -1411,11 +1411,11 @@ START_TEST(test_linklist_foldr_single)
 
 	free(out1);
 	free(out2);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_foldr_multiple)
+START_TEST(test_dl_foldr_multiple)
 {
 	int8_t in1 = 1;
 	int8_t in2 = 2;
@@ -1425,15 +1425,15 @@ START_TEST(test_linklist_foldr_multiple)
 	int8_t * out2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(int8_t));
+	dl_alloc(&list, sizeof(int8_t));
 
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
 
 	/* foldr (-) 0 [1, 2, 3] -> 2 */
-	out1 = linklist_foldr(list, (foldr_fn_t) foldr_fn, &init);
-	out2 = linklist_foldr(list, (foldr_fn_t) generic_fold_fn, &init);
+	out1 = dl_foldr(list, (foldr_fn_t) foldr_fn, &init);
+	out2 = dl_foldr(list, (foldr_fn_t) generic_fold_fn, &init);
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -1446,21 +1446,21 @@ START_TEST(test_linklist_foldr_multiple)
 
 	free(out1);
 	free(out2);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_foldl_empty)
+START_TEST(test_dl_foldl_empty)
 {
 	int8_t init = 0;
 	int8_t * out1;
 	int8_t * out2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(int8_t));
+	dl_alloc(&list, sizeof(int8_t));
 
-	out1 = linklist_foldl(list, (foldl_fn_t) foldl_fn, &init);
-	out2 = linklist_foldl(list, (foldl_fn_t) generic_fold_fn, &init);
+	out1 = dl_foldl(list, (foldl_fn_t) foldl_fn, &init);
+	out2 = dl_foldl(list, (foldl_fn_t) generic_fold_fn, &init);
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -1469,15 +1469,15 @@ START_TEST(test_linklist_foldl_empty)
 
 	ck_assert(!list->head);
 	ck_assert(!list->tail);
-	ck_assert(linklist_null(list));
+	ck_assert(dl_null(list));
 
 	free(out1);
 	free(out2);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_foldl_single)
+START_TEST(test_dl_foldl_single)
 {
 	int8_t in = 1;
 	int8_t init = 0;
@@ -1485,12 +1485,12 @@ START_TEST(test_linklist_foldl_single)
 	int8_t * out2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(in));
-	linklist_push_head(list, &in);
+	dl_alloc(&list, sizeof(in));
+	dl_push_head(list, &in);
 
 	/* foldl (-) 0 [1] -> -1 */
-	out1 = linklist_foldl(list, (foldl_fn_t) foldl_fn, &init);
-	out2 = linklist_foldl(list, (foldl_fn_t) generic_fold_fn, &init);
+	out1 = dl_foldl(list, (foldl_fn_t) foldl_fn, &init);
+	out2 = dl_foldl(list, (foldl_fn_t) generic_fold_fn, &init);
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -1503,11 +1503,11 @@ START_TEST(test_linklist_foldl_single)
 
 	free(out1);
 	free(out2);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-START_TEST(test_linklist_foldl_multiple)
+START_TEST(test_dl_foldl_multiple)
 {
 	int8_t in1 = 1;
 	int8_t in2 = 2;
@@ -1517,15 +1517,15 @@ START_TEST(test_linklist_foldl_multiple)
 	int8_t * out2;
 	struct linked_list * list;
 
-	linklist_alloc(&list, sizeof(int8_t));
+	dl_alloc(&list, sizeof(int8_t));
 
-	linklist_push_tail(list, &in1);
-	linklist_push_tail(list, &in2);
-	linklist_push_tail(list, &in3);
+	dl_push_tail(list, &in1);
+	dl_push_tail(list, &in2);
+	dl_push_tail(list, &in3);
 
 	/* foldl (-) 0 [1, 2, 3] -> -6 */
-	out1 = linklist_foldl(list, (foldl_fn_t) foldl_fn, &init);
-	out2 = linklist_foldl(list, (foldl_fn_t) generic_fold_fn, &init);
+	out1 = dl_foldl(list, (foldl_fn_t) foldl_fn, &init);
+	out2 = dl_foldl(list, (foldl_fn_t) generic_fold_fn, &init);
 
 	ck_assert(out1);
 	ck_assert(out2);
@@ -1538,144 +1538,144 @@ START_TEST(test_linklist_foldl_multiple)
 
 	free(out1);
 	free(out2);
-	linklist_free(&list);
+	dl_free(&list);
 }
 END_TEST
 
-Suite * linklist_suite(void)
+Suite * dl_suite(void)
 {
 	Suite * suite;
-	TCase * case_linklist_alloc;
-	TCase * case_linklist_null;
-	TCase * case_linklist_push_head;
-	TCase * case_linklist_push_tail;
-	TCase * case_linklist_pop_head;
-	TCase * case_linklist_pop_tail;
-	TCase * case_linklist_insert;
-	TCase * case_linklist_delete;
-	TCase * case_linklist_remove;
-	TCase * case_linklist_fetch;
-	TCase * case_linklist_contains;
-	TCase * case_linklist_any;
-	TCase * case_linklist_all;
-	TCase * case_linklist_filter;
-	TCase * case_linklist_drop_while;
-	TCase * case_linklist_take_while;
-	TCase * case_linklist_map;
-	TCase * case_linklist_reverse;
-	TCase * case_linklist_foldl;
-	TCase * case_linklist_foldr;
+	TCase * case_dl_alloc;
+	TCase * case_dl_null;
+	TCase * case_dl_push_head;
+	TCase * case_dl_push_tail;
+	TCase * case_dl_pop_head;
+	TCase * case_dl_pop_tail;
+	TCase * case_dl_insert;
+	TCase * case_dl_delete;
+	TCase * case_dl_remove;
+	TCase * case_dl_fetch;
+	TCase * case_dl_contains;
+	TCase * case_dl_any;
+	TCase * case_dl_all;
+	TCase * case_dl_filter;
+	TCase * case_dl_drop_while;
+	TCase * case_dl_take_while;
+	TCase * case_dl_map;
+	TCase * case_dl_reverse;
+	TCase * case_dl_foldl;
+	TCase * case_dl_foldr;
 
 	suite = suite_create("Linked List");
 
-	case_linklist_alloc = tcase_create("linklist_alloc");
-	case_linklist_null = tcase_create("linklist_null");
-	case_linklist_push_head = tcase_create("linklist_push_head");
-	case_linklist_push_tail = tcase_create("linklist_push_tail");
-	case_linklist_pop_head = tcase_create("linklist_pop_head");
-	case_linklist_pop_tail = tcase_create("linklist_pop_tail");
-	case_linklist_insert = tcase_create("linklist_insert");
-	case_linklist_delete = tcase_create("linklist_delete");
-	case_linklist_remove = tcase_create("linklist_remove");
-	case_linklist_fetch = tcase_create("linklist_fetch");
-	case_linklist_contains = tcase_create("linklist_contains");
-	case_linklist_any = tcase_create("linklist_any");
-	case_linklist_all = tcase_create("linklist_all");
-	case_linklist_filter = tcase_create("linklist_filter");
-	case_linklist_drop_while = tcase_create("linklist_drop_while");
-	case_linklist_take_while = tcase_create("linklist_take_while");
-	case_linklist_map = tcase_create("linklist_map");
-	case_linklist_reverse = tcase_create("linklist_reverse");
-	case_linklist_foldl = tcase_create("linklist_foldl");
-	case_linklist_foldr = tcase_create("linklist_foldr");
+	case_dl_alloc = tcase_create("dl_alloc");
+	case_dl_null = tcase_create("dl_null");
+	case_dl_push_head = tcase_create("dl_push_head");
+	case_dl_push_tail = tcase_create("dl_push_tail");
+	case_dl_pop_head = tcase_create("dl_pop_head");
+	case_dl_pop_tail = tcase_create("dl_pop_tail");
+	case_dl_insert = tcase_create("dl_insert");
+	case_dl_delete = tcase_create("dl_delete");
+	case_dl_remove = tcase_create("dl_remove");
+	case_dl_fetch = tcase_create("dl_fetch");
+	case_dl_contains = tcase_create("dl_contains");
+	case_dl_any = tcase_create("dl_any");
+	case_dl_all = tcase_create("dl_all");
+	case_dl_filter = tcase_create("dl_filter");
+	case_dl_drop_while = tcase_create("dl_drop_while");
+	case_dl_take_while = tcase_create("dl_take_while");
+	case_dl_map = tcase_create("dl_map");
+	case_dl_reverse = tcase_create("dl_reverse");
+	case_dl_foldl = tcase_create("dl_foldl");
+	case_dl_foldr = tcase_create("dl_foldr");
 
-	tcase_add_test(case_linklist_alloc, test_linklist_alloc);
-	tcase_add_test(case_linklist_null, test_linklist_null_true);
-	tcase_add_test(case_linklist_null, test_linklist_null_false);
-	tcase_add_test(case_linklist_push_head, test_linklist_push_head_single);
-	tcase_add_test(case_linklist_push_head, test_linklist_push_head_multiple);
-	tcase_add_test(case_linklist_push_tail, test_linklist_push_tail_single);
-	tcase_add_test(case_linklist_push_tail, test_linklist_push_tail_multiple);
-	tcase_add_test(case_linklist_pop_head, test_linklist_pop_head_empty);
-	tcase_add_test(case_linklist_pop_head, test_linklist_pop_head_single);
-	tcase_add_test(case_linklist_pop_head, test_linklist_pop_head_multiple);
-	tcase_add_test(case_linklist_pop_tail, test_linklist_pop_tail_empty);
-	tcase_add_test(case_linklist_pop_tail, test_linklist_pop_tail_single);
-	tcase_add_test(case_linklist_pop_tail, test_linklist_pop_tail_multiple);
-	tcase_add_test(case_linklist_insert, test_linklist_insert_single);
-	tcase_add_test(case_linklist_insert, test_linklist_insert_multiple);
-	tcase_add_test(case_linklist_delete, test_linklist_delete_empty);
-	tcase_add_test(case_linklist_delete, test_linklist_delete_single);
-	tcase_add_test(case_linklist_delete, test_linklist_delete_multiple);
-	tcase_add_test(case_linklist_remove, test_linklist_remove_empty);
-	tcase_add_test(case_linklist_remove, test_linklist_remove_single);
-	tcase_add_test(case_linklist_remove, test_linklist_remove_multiple);
-	tcase_add_test(case_linklist_fetch, test_linklist_fetch_empty);
-	tcase_add_test(case_linklist_fetch, test_linklist_fetch_single);
-	tcase_add_test(case_linklist_fetch, test_linklist_fetch_multiple);
-	tcase_add_test(case_linklist_contains, test_linklist_contains_empty);
-	tcase_add_test(case_linklist_contains, test_linklist_contains_single);
-	tcase_add_test(case_linklist_contains, test_linklist_contains_multiple);
-	tcase_add_test(case_linklist_any, test_linklist_any_empty);
-	tcase_add_test(case_linklist_any, test_linklist_any_single);
-	tcase_add_test(case_linklist_any, test_linklist_any_multiple);
-	tcase_add_test(case_linklist_all, test_linklist_all_empty);
-	tcase_add_test(case_linklist_all, test_linklist_all_single);
-	tcase_add_test(case_linklist_all, test_linklist_all_multiple);
-	tcase_add_test(case_linklist_filter, test_linklist_filter_empty);
-	tcase_add_test(case_linklist_filter, test_linklist_filter_single);
-	tcase_add_test(case_linklist_filter, test_linklist_filter_multiple);
-	tcase_add_test(case_linklist_drop_while, test_linklist_drop_while_empty);
-	tcase_add_test(case_linklist_drop_while, test_linklist_drop_while_single);
-	tcase_add_test(case_linklist_drop_while, test_linklist_drop_while_multiple);
-	tcase_add_test(case_linklist_take_while, test_linklist_take_while_empty);
-	tcase_add_test(case_linklist_take_while, test_linklist_take_while_single);
-	tcase_add_test(case_linklist_take_while, test_linklist_take_while_multiple);
-	tcase_add_test(case_linklist_map, test_linklist_map_empty);
-	tcase_add_test(case_linklist_map, test_linklist_map_single);
-	tcase_add_test(case_linklist_map, test_linklist_map_multiple);
-	tcase_add_test(case_linklist_reverse, test_linklist_reverse_empty);
-	tcase_add_test(case_linklist_reverse, test_linklist_reverse_single);
-	tcase_add_test(case_linklist_reverse, test_linklist_reverse_multiple);
-	tcase_add_test(case_linklist_foldr, test_linklist_foldr_empty);
-	tcase_add_test(case_linklist_foldr, test_linklist_foldr_single);
-	tcase_add_test(case_linklist_foldr, test_linklist_foldr_multiple);
-	tcase_add_test(case_linklist_foldl, test_linklist_foldl_empty);
-	tcase_add_test(case_linklist_foldl, test_linklist_foldl_single);
-	tcase_add_test(case_linklist_foldl, test_linklist_foldl_multiple);
+	tcase_add_test(case_dl_alloc, test_dl_alloc);
+	tcase_add_test(case_dl_null, test_dl_null_true);
+	tcase_add_test(case_dl_null, test_dl_null_false);
+	tcase_add_test(case_dl_push_head, test_dl_push_head_single);
+	tcase_add_test(case_dl_push_head, test_dl_push_head_multiple);
+	tcase_add_test(case_dl_push_tail, test_dl_push_tail_single);
+	tcase_add_test(case_dl_push_tail, test_dl_push_tail_multiple);
+	tcase_add_test(case_dl_pop_head, test_dl_pop_head_empty);
+	tcase_add_test(case_dl_pop_head, test_dl_pop_head_single);
+	tcase_add_test(case_dl_pop_head, test_dl_pop_head_multiple);
+	tcase_add_test(case_dl_pop_tail, test_dl_pop_tail_empty);
+	tcase_add_test(case_dl_pop_tail, test_dl_pop_tail_single);
+	tcase_add_test(case_dl_pop_tail, test_dl_pop_tail_multiple);
+	tcase_add_test(case_dl_insert, test_dl_insert_single);
+	tcase_add_test(case_dl_insert, test_dl_insert_multiple);
+	tcase_add_test(case_dl_delete, test_dl_delete_empty);
+	tcase_add_test(case_dl_delete, test_dl_delete_single);
+	tcase_add_test(case_dl_delete, test_dl_delete_multiple);
+	tcase_add_test(case_dl_remove, test_dl_remove_empty);
+	tcase_add_test(case_dl_remove, test_dl_remove_single);
+	tcase_add_test(case_dl_remove, test_dl_remove_multiple);
+	tcase_add_test(case_dl_fetch, test_dl_fetch_empty);
+	tcase_add_test(case_dl_fetch, test_dl_fetch_single);
+	tcase_add_test(case_dl_fetch, test_dl_fetch_multiple);
+	tcase_add_test(case_dl_contains, test_dl_contains_empty);
+	tcase_add_test(case_dl_contains, test_dl_contains_single);
+	tcase_add_test(case_dl_contains, test_dl_contains_multiple);
+	tcase_add_test(case_dl_any, test_dl_any_empty);
+	tcase_add_test(case_dl_any, test_dl_any_single);
+	tcase_add_test(case_dl_any, test_dl_any_multiple);
+	tcase_add_test(case_dl_all, test_dl_all_empty);
+	tcase_add_test(case_dl_all, test_dl_all_single);
+	tcase_add_test(case_dl_all, test_dl_all_multiple);
+	tcase_add_test(case_dl_filter, test_dl_filter_empty);
+	tcase_add_test(case_dl_filter, test_dl_filter_single);
+	tcase_add_test(case_dl_filter, test_dl_filter_multiple);
+	tcase_add_test(case_dl_drop_while, test_dl_drop_while_empty);
+	tcase_add_test(case_dl_drop_while, test_dl_drop_while_single);
+	tcase_add_test(case_dl_drop_while, test_dl_drop_while_multiple);
+	tcase_add_test(case_dl_take_while, test_dl_take_while_empty);
+	tcase_add_test(case_dl_take_while, test_dl_take_while_single);
+	tcase_add_test(case_dl_take_while, test_dl_take_while_multiple);
+	tcase_add_test(case_dl_map, test_dl_map_empty);
+	tcase_add_test(case_dl_map, test_dl_map_single);
+	tcase_add_test(case_dl_map, test_dl_map_multiple);
+	tcase_add_test(case_dl_reverse, test_dl_reverse_empty);
+	tcase_add_test(case_dl_reverse, test_dl_reverse_single);
+	tcase_add_test(case_dl_reverse, test_dl_reverse_multiple);
+	tcase_add_test(case_dl_foldr, test_dl_foldr_empty);
+	tcase_add_test(case_dl_foldr, test_dl_foldr_single);
+	tcase_add_test(case_dl_foldr, test_dl_foldr_multiple);
+	tcase_add_test(case_dl_foldl, test_dl_foldl_empty);
+	tcase_add_test(case_dl_foldl, test_dl_foldl_single);
+	tcase_add_test(case_dl_foldl, test_dl_foldl_multiple);
 
-	suite_add_tcase(suite, case_linklist_alloc);
-	suite_add_tcase(suite, case_linklist_null);
-	suite_add_tcase(suite, case_linklist_push_head);
-	suite_add_tcase(suite, case_linklist_push_tail);
-	suite_add_tcase(suite, case_linklist_pop_head);
-	suite_add_tcase(suite, case_linklist_pop_tail);
-	suite_add_tcase(suite, case_linklist_insert);
-	suite_add_tcase(suite, case_linklist_delete);
-	suite_add_tcase(suite, case_linklist_remove);
-	suite_add_tcase(suite, case_linklist_fetch);
-	suite_add_tcase(suite, case_linklist_contains);
-	suite_add_tcase(suite, case_linklist_any);
-	suite_add_tcase(suite, case_linklist_all);
-	suite_add_tcase(suite, case_linklist_filter);
-	suite_add_tcase(suite, case_linklist_drop_while);
-	suite_add_tcase(suite, case_linklist_take_while);
-	suite_add_tcase(suite, case_linklist_map);
-	suite_add_tcase(suite, case_linklist_reverse);
-	suite_add_tcase(suite, case_linklist_foldr);
-	suite_add_tcase(suite, case_linklist_foldl);
+	suite_add_tcase(suite, case_dl_alloc);
+	suite_add_tcase(suite, case_dl_null);
+	suite_add_tcase(suite, case_dl_push_head);
+	suite_add_tcase(suite, case_dl_push_tail);
+	suite_add_tcase(suite, case_dl_pop_head);
+	suite_add_tcase(suite, case_dl_pop_tail);
+	suite_add_tcase(suite, case_dl_insert);
+	suite_add_tcase(suite, case_dl_delete);
+	suite_add_tcase(suite, case_dl_remove);
+	suite_add_tcase(suite, case_dl_fetch);
+	suite_add_tcase(suite, case_dl_contains);
+	suite_add_tcase(suite, case_dl_any);
+	suite_add_tcase(suite, case_dl_all);
+	suite_add_tcase(suite, case_dl_filter);
+	suite_add_tcase(suite, case_dl_drop_while);
+	suite_add_tcase(suite, case_dl_take_while);
+	suite_add_tcase(suite, case_dl_map);
+	suite_add_tcase(suite, case_dl_reverse);
+	suite_add_tcase(suite, case_dl_foldr);
+	suite_add_tcase(suite, case_dl_foldl);
 
 	return suite;
 }
 
 int main(void)
 {
-	Suite * suite_linklist;
+	Suite * suite_dl;
 	SRunner * suite_runner;
 
-	suite_linklist = linklist_suite();
+	suite_dl = dl_suite();
 
-	suite_runner = srunner_create(suite_linklist);
+	suite_runner = srunner_create(suite_dl);
 	srunner_run_all(suite_runner, CK_NORMAL);
 	srunner_free(suite_runner);
 


### PR DESCRIPTION
This merge changes the names of the doubley linked list functions from linklist_func to dl_func to reduce confusion when singley linked lists are implemented.